### PR TITLE
[IMU driver]: stronger acc anti-aliasing filter

### DIFF
--- a/src/main/drivers/accgyro/accgyro_spi_bmi160.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi160.c
@@ -90,6 +90,10 @@
 #define BMI160_VAL_GYRO_CONF_BWP_OSR4 0x00
 #define BMI160_VAL_GYRO_CONF_BWP_OSR2 0x10
 #define BMI160_VAL_GYRO_CONF_BWP_NORM 0x20
+#define BMI160_VAL_ACC_CONF_BWP_OSR4 0x00
+#define BMI160_VAL_ACC_CONF_BWP_OSR2 0x10
+#define BMI160_VAL_ACC_CONF_BWP_NORM 0x20
+#define BMI160_VAL_ACC_CONF_US_HP 0x00
 
 // Need to see at least this many interrupts during initialisation to confirm EXTI connectivity
 #define GYRO_EXTI_DETECT_THRESHOLD 1000
@@ -184,8 +188,8 @@ static int32_t BMI160_Config(const extDevice_t *dev)
     }
 
     // Set odr and ranges
-    // Set acc_us = 0 acc_bwp = 0b010 so only the first filter stage is used
-    spiWriteReg(dev, BMI160_REG_ACC_CONF, 0x20 | BMI160_ODR_800_Hz);
+    // Set acc_us = 0 & acc_bwp = 0b001 for high performance and OSR2 mode
+    spiWriteReg(dev, BMI160_REG_ACC_CONF, BMI160_VAL_ACC_CONF_US_HP | BMI160_VAL_ACC_CONF_BWP_OSR2 | BMI160_ODR_800_Hz);
     delay(1);
 
     spiWriteReg(dev, BMI160_REG_GYR_CONF, getBmiOsrMode() | BMI160_ODR_3200_Hz);

--- a/src/main/drivers/accgyro/accgyro_spi_bmi270.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi270.c
@@ -110,7 +110,7 @@ typedef enum {
     BMI270_VAL_PAGE_0 = 0x00,                // select page 0
     BMI270_VAL_ACC_CONF_ODR800 = 0x0B,       // set acc sample rate to 800hz
     BMI270_VAL_ACC_CONF_ODR1600 = 0x0C,      // set acc sample rate to 1600hz
-    BMI270_VAL_ACC_CONF_BWP = 0x02,          // set acc filter in normal mode
+    BMI270_VAL_ACC_CONF_BWP = 0x01,          // set acc filter in osr2 mode
     BMI270_VAL_ACC_CONF_HP = 0x01,           // set acc in high performance mode
     BMI270_VAL_ACC_RANGE_8G = 0x02,          // set acc to 8G full scale
     BMI270_VAL_ACC_RANGE_16G = 0x03,         // set acc to 16G full scale

--- a/src/main/drivers/accgyro/accgyro_spi_lsm6dso_init.c
+++ b/src/main/drivers/accgyro/accgyro_spi_lsm6dso_init.c
@@ -155,8 +155,8 @@ static void lsm6dsoConfig(gyroDev_t *gyro)
     lsm6dsoWriteRegister(dev, LSM6DSO_REG_INT2_CTRL, LSM6DSO_VAL_INT2_CTRL, 1);
 
     // Configure the accelerometer
-    // 833hz ODR, 16G scale, use LPF1 output
-    lsm6dsoWriteRegister(dev, LSM6DSO_REG_CTRL1_XL, (LSM6DSO_VAL_CTRL1_XL_ODR833 << 4) | (LSM6DSO_VAL_CTRL1_XL_16G << 2) | (LSM6DSO_VAL_CTRL1_XL_LPF1 << 1), 1);
+    // 833hz ODR, 16G scale, use LPF2 output (default with ODR/4 cutoff)
+    lsm6dsoWriteRegister(dev, LSM6DSO_REG_CTRL1_XL, (LSM6DSO_VAL_CTRL1_XL_ODR833 << 4) | (LSM6DSO_VAL_CTRL1_XL_16G << 2) | (LSM6DSO_VAL_CTRL1_XL_LPF2 << 1), 1);
 
     // Configure the gyro
     // 6664hz ODR, 2000dps scale


### PR DESCRIPTION
- BMI160/270: ACC with OSR2 mode, cutoff at ODR/4
- LSM6DSO: LPF2 output with cutoff at ODR/4