### PR TITLE
fix i2c

### DIFF
--- a/src/main/build/debug_pin.c
+++ b/src/main/build/debug_pin.c
@@ -28,7 +28,11 @@
 #include "debug_pin.h"
 
 typedef struct dbgPinState_s {
+#if defined(AT32F43x)
+	gpio_type * gpio;
+#else
     GPIO_TypeDef *gpio;
+#endif
     uint32_t setBSRR;
     uint32_t resetBSRR;
 } dbgPinState_t;
@@ -73,6 +77,8 @@ void dbgPinHi(int index)
     if (dbgPinState->gpio) {
 #if defined(STM32F7) || defined(STM32H7)
         dbgPinState->gpio->BSRR = dbgPinState->setBSRR;
+#elif defined(AT32F43x)
+        dbgPinState->gpio->scr = dbgPinState->setBSRR;
 #else
         dbgPinState->gpio->BSRRL = dbgPinState->setBSRR;
 #endif
@@ -93,7 +99,9 @@ void dbgPinLo(int index)
 
     if (dbgPinState->gpio) {
 #if defined(STM32F7) || defined(STM32H7)
-        dbgPinState->gpio->BSRR = dbgPinState->resetBSRR;
+    	dbgPinState->gpio->BSRR = dbgPinState->resetBSRR;
+#elif defined(AT32F43x)
+        dbgPinState->gpio->scr = dbgPinState->resetBSRR;
 #else
         dbgPinState->gpio->BSRRL = dbgPinState->resetBSRR;
 #endif

--- a/src/main/drivers/bus_i2c_atbsp_init.c
+++ b/src/main/drivers/bus_i2c_atbsp_init.c
@@ -173,7 +173,7 @@ void i2cInit(I2CDevice device)
 //    HAL_I2C_Init(pHandle);
     i2c_reset( pHandle->i2cx);
     /* config i2c */
-    i2c_init( pHandle->i2cx, 0, I2Cx_CLKCTRL);
+    i2c_init( pHandle->i2cx, 0x0f, I2Cx_CLKCTRL);
 
     i2c_own_address1_set( pHandle->i2cx, I2C_ADDRESS_MODE_7BIT, 0x0);
 

--- a/src/main/target/AT32F437DEV/target.c
+++ b/src/main/target/AT32F437DEV/target.c
@@ -27,6 +27,8 @@
  #include "drivers/timer.h"
  #include "drivers/timer_def.h"
 
+#include "build/debug_pin.h"
+
  const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
  	DEF_TIM(TMR2, CH3, PB10, TIM_USE_ANY |TIM_USE_LED, 0,13,0), // PWM1 - OUT1 MCO1 DMA1 CH2
 	DEF_TIM(TMR2, CH4, PB11,  TIM_USE_ANY |TIM_USE_BEEPER, 0,12,0), // PWM2 - OUT1 DMA1 CH6
@@ -40,4 +42,11 @@
  	DEF_TIM(TMR4, CH3, PB8,  TIM_USE_MOTOR,  0,1,0), // motor3 DMA2 CH5
  	DEF_TIM(TMR4, CH4, PB9,  TIM_USE_MOTOR,  0,3,0), // motor4 DMA2 CH4
 
+ };
+
+
+ dbgPin_t dbgPins[DEBUG_PIN_COUNT] = {
+     { .tag = IO_TAG(PE0) },
+	 { .tag = IO_TAG(PE1) },
+	 { .tag = IO_TAG(PE2) },
  };

--- a/src/main/target/AT32F437DEV/target.h
+++ b/src/main/target/AT32F437DEV/target.h
@@ -38,6 +38,10 @@
  * PA10 OTG1
  */
 
+//debug
+#define USE_DEBUG_PIN
+#define DEBUG_PIN_COUNT         3
+
 //buttons
 #define USE_BUTTONS
 #define BUTTON_A_PIN            PD2
@@ -235,7 +239,7 @@
 #define TARGET_IO_PORTB         0xffff
 #define TARGET_IO_PORTC         0xffff
 #define TARGET_IO_PORTD         0xffff
-#define TARGET_IO_PORTE         BIT(2)
+#define TARGET_IO_PORTE         0xffff
 
 #define USABLE_TIMER_CHANNEL_COUNT 28
 #define USED_TIMERS             ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(5) | TIM_N(8) | TIM_N(20) )


### PR DESCRIPTION
在雅特力 涂工支持下，通过修改 i2c 超时时间、清Stop标志位等方式彻底修复I2c发送数据错误bug