### PR TITLE
[IMU driver]: Switch BMI270 to normal driver

### DIFF
--- a/lib/main/BoschSensortec/BMI270-Sensor-API/betaflight_info.txt
+++ b/lib/main/BoschSensortec/BMI270-Sensor-API/betaflight_info.txt
@@ -6,4 +6,4 @@ Library download location:
 Version:
     2.63.1
 
-The only file that is compiled as part of Betaflight is bmi270_maximum_fifo.c. This file contains the device microcode that must be uploaded during initialization. 
+The only file that is compiled as part of Betaflight is bmi270.c. This file contains the device microcode that must be uploaded during initialization. 

--- a/src/main/target/AT32F403ADEV/target.mk
+++ b/src/main/target/AT32F403ADEV/target.mk
@@ -5,7 +5,7 @@ FEATURES       += VCP SDCARD_SPI ONBOARDFLASH
 
 TARGET_SRC = \
     $(addprefix drivers/accgyro/,$(notdir $(wildcard $(SRC_DIR)/drivers/accgyro/*.c))) \
-    $(ROOT)/lib/main/BoschSensortec/BMI270-Sensor-API/bmi270_maximum_fifo.c \
+    $(ROOT)/lib/main/BoschSensortec/BMI270-Sensor-API/bmi270.c \
     $(addprefix drivers/barometer/,$(notdir $(wildcard $(SRC_DIR)/drivers/barometer/*.c))) \
     $(addprefix drivers/compass/,$(notdir $(wildcard $(SRC_DIR)/drivers/compass/*.c))) \
     drivers/max7456.c \

--- a/src/main/target/EMSRPROTO2/target.mk
+++ b/src/main/target/EMSRPROTO2/target.mk
@@ -8,7 +8,7 @@ TARGET_SRC = \
             drivers/barometer/barometer_bmp280.c \
             drivers/compass/compass_hmc5883l.c\
             drivers/compass/compass_qmc5883l.c\
-            $(ROOT)/lib/main/BoschSensortec/BMI270-Sensor-API/bmi270_maximum_fifo.c \
+            $(ROOT)/lib/main/BoschSensortec/BMI270-Sensor-API/bmi270.c \
             drivers/accgyro/accgyro_spi_bmi270.c\
             drivers/accgyro/accgyro_spi_lsm6dso_init.c \
             drivers/accgyro/accgyro_spi_lsm6dso.c \

--- a/src/main/target/EMSRPROTO3/target.mk
+++ b/src/main/target/EMSRPROTO3/target.mk
@@ -8,7 +8,7 @@ TARGET_SRC = \
             drivers/barometer/barometer_bmp280.c \
             drivers/compass/compass_hmc5883l.c\
             drivers/compass/compass_qmc5883l.c\
-            $(ROOT)/lib/main/BoschSensortec/BMI270-Sensor-API/bmi270_maximum_fifo.c \
+            $(ROOT)/lib/main/BoschSensortec/BMI270-Sensor-API/bmi270.c \
             drivers/accgyro/accgyro_spi_bmi270.c\
             drivers/max7456.c \
 

--- a/src/main/target/NEUTRONRCF435AIO/target.mk
+++ b/src/main/target/NEUTRONRCF435AIO/target.mk
@@ -13,7 +13,7 @@ TARGET_SRC = \
             drivers/barometer/barometer_dps310.c\
             drivers/compass/compass_hmc5883l.c\
             drivers/compass/compass_qmc5883l.c\
-            $(ROOT)/lib/main/BoschSensortec/BMI270-Sensor-API/bmi270_maximum_fifo.c \
+            $(ROOT)/lib/main/BoschSensortec/BMI270-Sensor-API/bmi270.c \
             drivers/accgyro/accgyro_spi_bmi270.c\
             drivers/accgyro/accgyro_spi_lsm6dso_init.c \
             drivers/accgyro/accgyro_spi_lsm6dso.c \


### PR DESCRIPTION
Switch to BMI270 "normal" driver due to performance consideration.

Before:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:         524 B        10 KB      5.12%
FLASH_CUSTOM_DEFAULTS:           8 B         6 KB      0.13%
    FLASH_CONFIG:          0 GB        16 KB      0.00%
          FLASH1:      477283 B       976 KB     47.76%
FLASH_CUSTOM_DEFAULTS_EXTENDED:          0 GB        16 KB      0.00%
   SYSTEM_MEMORY:          0 GB        16 KB      0.00%
            RAM1:       41552 B        64 KB     63.40%
             RAM:       68204 B       128 KB     52.04%
       MEMORY_B1:          0 GB         0 GB
   text    data     bss     dec     hex filename
 471499    6316   87652  565467   8a0db ./obj/main/betaflight_NEUTRONRCF435AIO.elf
Creating HEX ./obj/betaflight_4.3.2_NEUTRONRCF435AIO_67b2ccb6a.hex 
```

After:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:         524 B        10 KB      5.12%
FLASH_CUSTOM_DEFAULTS:           8 B         6 KB      0.13%
    FLASH_CONFIG:          0 GB        16 KB      0.00%
          FLASH1:      485147 B       976 KB     48.54%
FLASH_CUSTOM_DEFAULTS_EXTENDED:          0 GB        16 KB      0.00%
   SYSTEM_MEMORY:          0 GB        16 KB      0.00%
            RAM1:       41552 B        64 KB     63.40%
             RAM:       68204 B       128 KB     52.04%
       MEMORY_B1:          0 GB         0 GB
   text    data     bss     dec     hex filename
 479363    6316   87652  573331   8bf93 ./obj/main/betaflight_NEUTRONRCF435AIO.elf
Creating HEX ./obj/betaflight_4.3.2_NEUTRONRCF435AIO_4b3f10d62.hex 
```

Flash size increase 7864 bytes.