### PR TITLE
[Driver]: Swap TXRX to avoid DFU-hijacking and decrease i2c timeout

### DIFF
--- a/src/main/drivers/bus_i2c_atbsp.c
+++ b/src/main/drivers/bus_i2c_atbsp.c
@@ -38,7 +38,7 @@
 #include "drivers/bus_i2c_impl.h"
 
 //#define I2C_TIMEOUT                      0x3FFFFF
-#define I2C_TIMEOUT                      0x8700 //about 120 us at 288 mhz
+#define I2C_TIMEOUT                      0x870 //about 7 us at 288 mhz
 
 #ifdef USE_I2C_DEVICE_1
 void I2C1_ERR_IRQHandler(void)
@@ -287,7 +287,7 @@ bool i2cReadBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, u
     else
     {
       /* wait for the communication to end */
-      i2c_wait_end(pHandle->i2cx, I2C_TIMEOUT);
+    //   i2c_wait_end(pHandle->i2cx, I2C_TIMEOUT);
     }
 
 


### PR DESCRIPTION
尝试修正2个bug:
* BUG1 : NEUTRONRCF435AIO 在串口 1、4 接elrs的情况下，长按Boot 按钮插usb线，受elrs干扰无法进入到usb dfu模式，无法进行固件升级
* BUG2 ：一定的情况下 NEUTRONRCF435AIO i2c 产生超过1800us的delay，怀疑与i2c异常错误有关，此delay导致炸机

解决方案：
* BUG1：通过增加 uart pin swap 特性，swap target uart1、uart4 TX\RX pin  （uart2 接了sbus 反相器不能修改，UART4 使用的是PC11 PC10 针脚），同时为了保持用户使用习惯，互换 uart5 TX/RX pin 

**注意：** 用户需要改变焊接习惯，ELRS 接收机TX 需要改为接 飞控 TX ，ELRS RX 改为接飞控RX

* BUG2 : I2C WAIT END time delay 缩短到原来的1/10 

结果：
BUG1 : 测试串口 1、4、5 焊接elrs 接收机正常通信， 能够正常进DFU 模式
BUG2:  NEUTRONRCF435AIO  默认DPS310 气压计功能正常，未出现delay情况


```
# tasks
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms   late    run reqd/us
00 - (         SYSTEM)     10      18       0    0.0%    0.0%         0      4   1014      12
01 - (         SYSTEM)    978      26       0    2.5%    0.0%        34    214  99311      16
02 - (           GYRO)   3163      33       7   10.4%    2.2%      2287      0 321013       0
03 - (         FILTER)   3163      50      22   15.8%    7.0%      7203      0 321013       0
04 - (            PID)   3163      64      37   20.2%   11.7%     12062      0 321013       0
05 - (            ACC)    791      10       1    0.7%    0.1%       135     47  80172       1
06 - (       ATTITUDE)    100      29       3    0.2%    0.0%        41      5  10125      23
07 - (             RX)    250      29       7    0.7%    0.1%       560     10  74469       9
08 - (         SERIAL)     99     154       0    1.5%    0.0%       155      0  10027     110
09 - (       DISPATCH)    974      25       0    2.4%    0.0%        44    133  99345      17
10 - (BATTERY_VOLTAGE)     50      21       1    0.1%    0.0%         5      9   5064      16
11 - (BATTERY_CURRENT)     50      18       0    0.0%    0.0%         1      5   5064       1
12 - ( BATTERY_ALERTS)      5       2       0    0.0%    0.0%         0      2    507       0
13 - (         BEEPER)     99      18       0    0.1%    0.0%         3      6  10027       1
16 - (           BARO)     37      45       6    0.1%    0.0%        68     12  12129      20
17 - (       ALTITUDE)     40      22       3    0.0%    0.0%        13      6   4053      20
19 - (      TELEMETRY)    491      35       0    1.7%    0.0%       115     33  49895      16
20 - (       LEDSTRIP)     99      60       1    0.5%    0.0%        12      1  10027      53
21 - (            OSD)     12     152      14    0.1%    0.0%       197     31  19874     123
23 - (            CMS)     20      24       2    0.0%    0.0%         1     10   2027      23
24 - (        VTXCTRL)      5      19       0    0.0%    0.0%         0      1    507      16
25 - (        CAMCTRL)      5      18       0    0.0%    0.0%         0      1    507      15
27 - (    ADCINTERNAL)      1      21       3    0.0%    0.0%         0      1    102      20
29 - (SPEED_NEGOTIATION)     99      18       0    0.1%    0.0%         4      4  10027       2
RX Check Function                  28       0                        80
Total (excluding SERIAL)                                21.1%
```
