### PR TITLE
[New Target]: Add standard QFN48 target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        targets: [ EMSRPROTO1, EMSRPROTO2, EMSRPROTO3, NEUTRONRCF435AIO ]
+        targets: [ EMSRPROTO1, EMSRPROTO2, EMSRPROTO3, NEUTRONRCF435AIO, NEUTRONRCF435MINI ]
     steps:
       - name: Code Checkout
         uses: actions/checkout@v2

--- a/src/main/drivers/bus_i2c_atbsp_init.c
+++ b/src/main/drivers/bus_i2c_atbsp_init.c
@@ -78,10 +78,12 @@ const i2cHardware_t i2cHardware[I2CDEV_COUNT] = {
         .sclPins = {
             I2CPINDEF(PB10, GPIO_MUX_4),
             I2CPINDEF(PD12, GPIO_MUX_4),
+	    I2CPINDEF(PH2,  GPIO_MUX_4),
         },
         .sdaPins = {
             I2CPINDEF(PB3, GPIO_MUX_4),
             I2CPINDEF(PB11, GPIO_MUX_4),
+	    I2CPINDEF(PH3,GPIO_MUX_4),
         },
         .rcc = RCC_APB1(I2C2),
         .ev_irq = I2C2_EVT_IRQn,
@@ -97,7 +99,7 @@ const i2cHardware_t i2cHardware[I2CDEV_COUNT] = {
         },
         .sdaPins = {
             I2CPINDEF(PC1, GPIO_MUX_4),
-			I2CPINDEF(PB14, GPIO_MUX_4),
+	    I2CPINDEF(PB14, GPIO_MUX_4),
         },
         .rcc = RCC_APB1(I2C3),
         .ev_irq = I2C3_EVT_IRQn,

--- a/src/main/drivers/serial_uart_at32f43x.c
+++ b/src/main/drivers/serial_uart_at32f43x.c
@@ -67,6 +67,12 @@
 #ifndef UART5_RX_DMA_CHANNEL
 #define UART5_RX_DMA_CHANNEL NULL
 #endif
+#ifndef UART7_TX_DMA_CHANNEL
+#define UART7_TX_DMA_CHANNEL NULL
+#endif
+#ifndef UART7_RX_DMA_CHANNEL
+#define UART7_RX_DMA_CHANNEL NULL
+#endif
 #ifndef UART8_TX_DMA_CHANNEL
 #define UART8_TX_DMA_CHANNEL NULL
 #endif
@@ -215,9 +221,9 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         },
         .txPins = {
                 { DEFIO_TAG_E(PB6), GPIO_MUX_8 },
-				{ DEFIO_TAG_E(PB9), GPIO_MUX_8 },
-				{ DEFIO_TAG_E(PC12), GPIO_MUX_8 },
-				{ DEFIO_TAG_E(PE10), GPIO_MUX_8 },
+		{ DEFIO_TAG_E(PB9), GPIO_MUX_8 },
+		{ DEFIO_TAG_E(PC12), GPIO_MUX_8 },
+		{ DEFIO_TAG_E(PE10), GPIO_MUX_8 },
         },
         .rcc = RCC_APB1(UART5),
         .irqn = UART5_IRQn,
@@ -230,6 +236,38 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
     },
 #endif
 
+#ifdef USE_UART7
+    {
+        .device = UARTDEV_7,
+        .reg = UART7,
+#ifdef USE_DMA
+        .rxDMAMuxId = DMAMUX_DMAREQ_ID_UART7_RX,
+        .rxDMAResource = (dmaResource_t *)UART7_RX_DMA_CHANNEL,
+        .txDMAMuxId = DMAMUX_DMAREQ_ID_UART7_TX,
+        .txDMAResource = (dmaResource_t *)UART7_TX_DMA_CHANNEL,
+#endif
+        .rxPins = {
+            { DEFIO_TAG_E(PB3), GPIO_MUX_8 },
+            { DEFIO_TAG_E(PC0), GPIO_MUX_8 },
+	    { DEFIO_TAG_E(PE7), GPIO_MUX_8 },
+	    { DEFIO_TAG_E(PF6), GPIO_MUX_8 },
+        },
+        .txPins = {
+                { DEFIO_TAG_E(PB4), GPIO_MUX_8 },
+		{ DEFIO_TAG_E(PC1), GPIO_MUX_8 },
+		{ DEFIO_TAG_E(PE8), GPIO_MUX_8 },
+		{ DEFIO_TAG_E(PF7), GPIO_MUX_8 },
+        },
+        .rcc = RCC_APB1(UART7),
+        .irqn = UART7_IRQn,
+        .txPriority = NVIC_PRIO_SERIALUART7_TXDMA,
+        .rxPriority = NVIC_PRIO_SERIALUART7,
+        .txBuffer = uart7TxBuffer,
+        .rxBuffer = uart7RxBuffer,
+        .txBufferSize = sizeof(uart7TxBuffer),
+        .rxBufferSize = sizeof(uart7RxBuffer),
+    },
+#endif
 
 #ifdef USE_UART8
     {

--- a/src/main/io/displayport_crsf.c
+++ b/src/main/io/displayport_crsf.c
@@ -85,7 +85,7 @@ static int crsfWriteString(displayPort_t *displayPort, uint8_t col, uint8_t row,
     if (row >= crsfScreen.rows || col >= crsfScreen.cols) {
         return 0;
     }
-    const size_t truncLen = MIN((int)strlen(s), crsfScreen.cols-col);  // truncate at colCount
+    const uint8_t  truncLen = MIN((int)strlen(s), crsfScreen.cols-col);  // truncate at colCount
     char *rowStart = &crsfScreen.buffer[row * crsfScreen.cols + col];
     crsfScreen.updated |= memcmp(rowStart, s, truncLen);
     if (crsfScreen.updated) {

--- a/src/main/target/NEUTRONRCF435MINI/target.c
+++ b/src/main/target/NEUTRONRCF435MINI/target.c
@@ -1,0 +1,38 @@
+/* * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+#include "drivers/io.h"
+
+#include "drivers/dma.h"
+#include "drivers/timer.h"
+#include "drivers/timer_def.h"
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+    DEF_TIM(TMR1, CH1, PA8, TIM_USE_ANY | TIM_USE_LED, 0, 7, 2),             // PWM1 - OUT1  LEDSTRIP /MCO1
+
+    DEF_TIM(TMR4, CH1, PB6,  TIM_USE_MOTOR, 0, 0, 0), // motor1 DMA1 CH1
+    DEF_TIM(TMR1, CH3, PA10, TIM_USE_MOTOR, 0, 1, 0), // motor2 DMA1 CH2
+    DEF_TIM(TMR2, CH4, PA3,  TIM_USE_MOTOR, 0, 2, 1), // motor3 DMA1 CH3
+    DEF_TIM(TMR3, CH4, PB1,  TIM_USE_MOTOR, 0, 3, 1), // motor4 DMA1 CH4
+
+
+};

--- a/src/main/target/NEUTRONRCF435MINI/target.h
+++ b/src/main/target/NEUTRONRCF435MINI/target.h
@@ -1,0 +1,194 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "NEUTRONRCF435MINI"
+#define USBD_PRODUCT_STRING     "NERC"
+/**********swd debuger reserved *****************
+ *
+ * pa13	swdio
+ * pa14 swclk
+ * PB4 JREST
+ *
+ * other pin
+ *
+ * BOOT0 button
+ * PA8  MCO1/EXINT
+ * PA12 OTG1 D+ DP
+ * PA11 OTG1 D- DM
+ * PH0 HEXT IN
+ * PH1 HEXT OUT
+ * PB2 BOOT1 -> GND
+ */
+
+//No Buttons
+
+//LEDS
+#define LED0_PIN        PC13
+#define LED1_PIN        PC14
+#define LED0_INVERTED        //PC 13\PC14  驱动电流不够，改为反向驱动LED
+#define LED1_INVERTED
+
+#define USE_BEEPER
+#define BEEPER_PIN      PC15
+#define BEEPER_INVERTED		 //低电平触发
+
+//ESC Protocol
+
+#define ENABLE_DSHOT_DMAR       DSHOT_DMAR_AUTO
+#define DSHOT_BITBANG_DEFAULT   DSHOT_BITBANG_AUTO
+
+// *************** SPI **********************
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+#define SPI1_NSS_PIN            PA4
+
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+#define SPI2_NSS_PIN            PB12
+
+
+// *************** Gyro & ACC **********************
+
+#define USE_EXTI
+#define USE_GYRO_EXTI
+#define GYRO_1_EXTI_PIN        PA15
+#define USE_MPU_DATA_READY_SIGNAL
+#define ENSURE_MPU_DATA_READY_IS_LOW
+
+#define GYRO_1_CS_PIN          SPI1_NSS_PIN
+#define GYRO_1_SPI_INSTANCE    SPI1
+#define GYRO_1_ALIGN           CW180_DEG
+
+
+#define USE_GYRO
+#define USE_GYRO_SPI_MPU6500  //debug only
+#define USE_ACC_SPI_MPU6500		//debug only
+#define USE_GYRO_SPI_ICM42688P
+#define USE_ACCGYRO_BMI270
+#define USE_ACCGYRO_LSM6DSO
+
+#define USE_ACC
+#define USE_ACC_SPI_ICM42688P
+
+
+// *************** OSD *****************************
+//USE SPI3 ON AT-START BOARD ,USE SPI2 ON LQFP64
+#define USE_MAX7456
+#define MAX7456_SPI_INSTANCE    SPI2
+#define MAX7456_SPI_CS_PIN      SPI2_NSS_PIN
+
+/********************BLACKBOX***********************/
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+#define USE_FLASH_W25N01G          // 1Gb NAND flash support
+#define USE_FLASH_W25M             // Stacked die support
+#define USE_FLASH_W25M512          // 512Kb (256Kb x 2 stacked) NOR flash support
+#define USE_FLASH_W25M02G          // 2Gb (1Gb x 2 stacked) NAND flash support
+#define FLASH_SPI_INSTANCE      SPI2
+#define FLASH_CS_PIN            PB5
+
+
+
+// *************** Baro **************************
+#define USE_I2C
+#define USE_I2C_DEVICE_2
+#define I2C_DEVICE              (I2CDEV_2)
+#define I2C2_SCL                PH2 // SCL pad 
+#define I2C2_SDA                PH3 // SDA pad
+#define USE_I2C_PULLUP
+
+#define USE_BARO
+#define USE_BARO_BMP280
+#define USE_BARO_DPS310
+#define BARO_I2C_INSTANCE       (I2CDEV_2)
+
+#define USE_MAG
+#define USE_MAG_HMC5883
+#define USE_MAG_QMC5883
+#define MAG_I2C_INSTANCE        (I2CDEV_2)
+
+
+// *************** UART & Serial ******************
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_RX_PIN            PB7  //PA10 CHANGE TO PB7
+#define UART1_TX_PIN            PA9
+
+#define USE_UART2
+#define UART2_RX_PIN            PB0 //PA3 CHANGE TO PB0
+#define UART2_TX_PIN            PA2
+
+#define USE_UART3
+#define UART3_RX_PIN            PB10
+#define UART3_TX_PIN            PB11
+
+#define USE_UART5
+#define UART5_RX_PIN            PB8
+#define UART5_TX_PIN            PB9
+
+#define USE_UART7
+#define UART7_RX_PIN            PB3
+#define UART7_TX_PIN            PB4
+
+
+
+#define USE_SOFTSERIAL1
+#define USE_SOFTSERIAL2
+
+#define SERIAL_PORT_COUNT       8 // VCP  UART1 UART2 UART3 UART5 UART7 SOFTSERIAL 1/2
+
+#define DEFAULT_RX_FEATURE      FEATURE_RX_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_SBUS
+#define SERIALRX_UART           SERIAL_PORT_USART1
+
+
+
+// *************** ADC *****************************
+#define USE_ADC
+#define ADC_INSTANCE         ADC1  // Default added
+#define ADC1_DMA_OPT            11  //DMA 2 CH 5
+
+#define VBAT_ADC_PIN            PA0
+#define CURRENT_METER_ADC_PIN   PA1
+//#define RSSI_ADC_PIN            0
+
+#define USE_ESCSERIAL
+
+#define DEFAULT_FEATURES                (FEATURE_OSD | FEATURE_TELEMETRY | FEATURE_SOFTSERIAL |FEATURE_LED_STRIP )
+#define DEFAULT_VOLTAGE_METER_SOURCE    VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SOURCE    CURRENT_METER_ADC
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTH         BIT(1)|BIT(2)|BIT(3)
+
+#define USABLE_TIMER_CHANNEL_COUNT 28
+#define USED_TIMERS             ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(5) | TIM_N(8) | TIM_N(20) )

--- a/src/main/target/NEUTRONRCF435MINI/target.mk
+++ b/src/main/target/NEUTRONRCF435MINI/target.mk
@@ -1,0 +1,28 @@
+#AT32F43xxMT7_TARGETS += $(TARGET)	#FOR 4032KB 
+AT32F43xxGT7_TARGETS += $(TARGET) #FOR 1024KB
+
+CUSTOM_DEFAULTS_EXTENDED = yes
+FEATURES       +=  VCP ONBOARDFLASH
+
+TARGET_SRC = \
+        drivers/accgyro/accgyro_mpu6500.c \
+        drivers/accgyro/accgyro_spi_mpu6000.c \
+        drivers/accgyro/accgyro_spi_mpu6500.c\
+        drivers/accgyro/accgyro_spi_icm426xx.c\
+        drivers/barometer/barometer_bmp280.c \
+        drivers/barometer/barometer_dps310.c\
+        drivers/compass/compass_hmc5883l.c\
+        drivers/compass/compass_qmc5883l.c\
+        $(ROOT)/lib/main/BoschSensortec/BMI270-Sensor-API/bmi270.c \
+        drivers/accgyro/accgyro_spi_bmi270.c\
+        drivers/accgyro/accgyro_spi_lsm6dso_init.c \
+        drivers/accgyro/accgyro_spi_lsm6dso.c \
+        drivers/max7456.c \
+        drivers/vtx_rtc6705.c \
+        drivers/vtx_rtc6705_soft_spi.c \
+        drivers/rx/expresslrs_driver_atbsp.c \
+        drivers/rx/rx_sx127x.c \
+        drivers/rx/rx_sx1280.c \
+        rx/expresslrs_telemetry.c \
+        rx/expresslrs_common.c \
+        rx/expresslrs.c


### PR DESCRIPTION
增加 AT32F435CUG7  QFN48  target for NEUTRONRCF435MINI based on  the latest 4.3-bsp-rebase