### PR TITLE
[IMU Driver]: Correct CAS compensation according to BMI270 official api

### DIFF
--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -122,7 +122,7 @@ typedef struct gyroDev_s {
     uint32_t gyroSyncEXTI;
     int32_t gyroShortPeriod;
     int32_t gyroDmaMaxDuration;
-    busSegment_t segments[3];
+    busSegment_t segments[2];
 #endif
     volatile bool dataReady;
     bool gyro_high_fsr;


### PR DESCRIPTION
```
# tasks
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms   late    run reqd/us
00 - (         SYSTEM)     10       1       0    0.0%    0.0%         0      0    115       0
01 - (         SYSTEM)    997      17       0    1.6%    0.0%         2     18  11315       0
02 - (           GYRO)   3239      19       1    6.1%    0.5%        49      0  36646       0
03 - (         FILTER)   3239      33      12   10.6%    4.1%       477      0  36646       0
04 - (            PID)   3239      35      15   11.3%    4.9%       569      0  36646       0
05 - (            ACC)    798      19       1    1.5%    0.1%        15     12   9083      17
06 - (       ATTITUDE)    100      20       3    0.2%    0.0%         4      1   1139      17
07 - (             RX)     10      29       7    0.0%    0.0%         2      6    345      25
08 - (         SERIAL)     98   69069       0  676.8%    0.0%       130      0   1131     220
09 - (       DISPATCH)    997      17       0    1.6%    0.0%         3     11  11307       1
10 - (BATTERY_VOLTAGE)     50      17       1    0.0%    0.0%         0      2    571      16
11 - (BATTERY_CURRENT)     50       1       0    0.0%    0.0%         0      4    571       0
12 - ( BATTERY_ALERTS)      5       1       0    0.0%    0.0%         0      0     58       0
13 - (         BEEPER)     98      16       0    0.1%    0.0%         0      2   1130       7
19 - (      TELEMETRY)    493      22       0    1.0%    0.0%         6      3   5623       0
20 - (       LEDSTRIP)     98      62       1    0.6%    0.0%         1      1   1130      61
21 - (            OSD)     12     147      14    0.1%    0.0%        23     23   2128     145
23 - (            CMS)     20       1       0    0.0%    0.0%         0      0    229       1
24 - (        VTXCTRL)      5       1       0    0.0%    0.0%         0      0     58       0
25 - (        CAMCTRL)      5       1       0    0.0%    0.0%         0      2     58       0
27 - (    ADCINTERNAL)      1       4       2    0.0%    0.0%         0      0     12       4
29 - (SPEED_NEGOTIATION)     98      16       0    0.1%    0.0%         0      1   1130       9
RX Check Function                  19       2                         5
Total (excluding SERIAL)                                 9.6%
```