### PR TITLE
[Target Update]: Fix mini target motor2 pwm output

### DIFF
--- a/src/main/target/NEUTRONRCF435MINI/target.c
+++ b/src/main/target/NEUTRONRCF435MINI/target.c
@@ -27,12 +27,12 @@
 #include "drivers/timer_def.h"
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
-    DEF_TIM(TMR1, CH1, PA8, TIM_USE_ANY | TIM_USE_LED, 0, 7, 2),             // PWM1 - OUT1  LEDSTRIP /MCO1
+    DEF_TIM(TMR1, CH1, PA8, TIM_USE_ANY | TIM_USE_LED, 0, 7, 1),             // PWM1 - OUT1  LEDSTRIP /MCO1
 
     DEF_TIM(TMR4, CH1, PB6,  TIM_USE_MOTOR, 0, 0, 0), // motor1 DMA1 CH1
-    DEF_TIM(TMR1, CH3, PA10, TIM_USE_MOTOR, 0, 1, 0), // motor2 DMA1 CH2
-    DEF_TIM(TMR2, CH4, PA3,  TIM_USE_MOTOR, 0, 2, 1), // motor3 DMA1 CH3
-    DEF_TIM(TMR3, CH4, PB1,  TIM_USE_MOTOR, 0, 3, 1), // motor4 DMA1 CH4
+    DEF_TIM(TMR4, CH2, PB7,  TIM_USE_MOTOR, 0, 1, 1), // motor2 DMA1 CH2
+    DEF_TIM(TMR2, CH4, PA3,  TIM_USE_MOTOR, 0, 2, 2), // motor3 DMA1 CH3
+    DEF_TIM(TMR3, CH4, PB1,  TIM_USE_MOTOR, 0, 3, 3), // motor4 DMA1 CH4
 
 
 };

--- a/src/main/target/NEUTRONRCF435MINI/target.h
+++ b/src/main/target/NEUTRONRCF435MINI/target.h
@@ -142,7 +142,7 @@
 #define USE_VCP
 
 #define USE_UART1
-#define UART1_RX_PIN            PB7  //PA10 CHANGE TO PB7
+#define UART1_RX_PIN            PA10
 #define UART1_TX_PIN            PA9
 
 #define USE_UART2


### PR DESCRIPTION
NEUTRONRCF435MINI MOTOR2 timer 和 LED_STRIP 的timer 在使用pwm电调协议的时候会产生配置冲突， 修改 motor2 针脚,与 Rx1 互换，已测试通过