### PR TITLE
[Chore]: Change default USBD product string

### DIFF
--- a/lib/main/AT32F43x/usbd_class/cdc/cdc_desc.h
+++ b/lib/main/AT32F43x/usbd_class/cdc/cdc_desc.h
@@ -68,7 +68,7 @@ extern "C" {
   * @brief usb string define(vendor, product configuration, interface)
   */
 #define USBD_CDC_DESC_MANUFACTURER_STRING    "Artery"
-#define USBD_CDC_DESC_PRODUCT_STRING         "AT32 Virtual Com Port  "
+#define USBD_CDC_DESC_PRODUCT_STRING         "FlightNG AT32 FC       "
 #define USBD_CDC_DESC_CONFIGURATION_STRING   "Virtual ComPort Config"
 #define USBD_CDC_DESC_INTERFACE_STRING       "Virtual ComPort Interface"
 


### PR DESCRIPTION
`AT32 Virtual Com Port` -> `FlightNG AT32 FC`