### PR TITLE
[Target Update]: Add asm330 for at32f437 dev board

### DIFF
--- a/src/main/target/AT32F437DEV/target.mk
+++ b/src/main/target/AT32F437DEV/target.mk
@@ -21,6 +21,8 @@ TARGET_SRC = \
             drivers/accgyro/accgyro_spi_qmi8658.c \
             drivers/accgyro/accgyro_spi_sh3001_init.c \
             drivers/accgyro/accgyro_spi_sh3001.c \
+            drivers/accgyro/accgyro_spi_asm330lhh_init.c \
+            drivers/accgyro/accgyro_spi_asm330lhh.c \
             drivers/max7456.c \
             drivers/vtx_rtc6705.c \
             drivers/vtx_rtc6705_soft_spi.c \


### PR DESCRIPTION
修复默认调试用的at32 dev board 未增加asm330 驱动问题