### PR TITLE
disable more irqs to fix am32 flash errors

### DIFF
--- a/src/main/io/serial_4way_avrootloader.c
+++ b/src/main/io/serial_4way_avrootloader.c
@@ -164,22 +164,19 @@ static uint8_t BL_ReadBuf(uint8_t *pstring, uint8_t len)
  *  后继处理： 测试通过后，尝试atomic_block(nvic_prio_max) 方式
  */
 #if defined(AT32F43x)
-    {
-        //disable exint
-        ExIntReg=EXINT->inten;
-        EXINT->inten=0;//DISABLE ALL EXINT
-        //disable 5-15 EXINT
-        NVIC_DisableIRQ(EXINT9_5_IRQn);
-        NVIC_DisableIRQ(EXINT15_10_IRQn);
-        //disable USB TIMER
-        NVIC_DisableIRQ(TMR20_OVF_IRQn);
-        //disable USB
-        NVIC_DisableIRQ(OTGFS1_IRQn);
-        //disable uart 1\2
-        NVIC_DisableIRQ(USART1_IRQn);
-        NVIC_DisableIRQ(USART2_IRQn);
-        NVIC_DisableIRQ(USART3_IRQn);
-    }
+    //disable exint
+    ExIntReg=EXINT->inten;
+    EXINT->inten=0;//DISABLE ALL EXINT
+    //disable 5-15 EXINT
+    NVIC_DisableIRQ(EXINT9_5_IRQn);
+    NVIC_DisableIRQ(EXINT15_10_IRQn);
+    //disable USB
+    NVIC_DisableIRQ(TMR20_OVF_IRQn);
+    NVIC_DisableIRQ(OTGFS1_IRQn);
+    //disable uart 1\2\3
+    NVIC_DisableIRQ(USART1_IRQn);
+    NVIC_DisableIRQ(USART2_IRQn);
+    NVIC_DisableIRQ(USART3_IRQn);
 #endif
     do {
         if (!suart_getc_(pstring)) goto timeout;
@@ -201,19 +198,17 @@ static uint8_t BL_ReadBuf(uint8_t *pstring, uint8_t len)
     }
 timeout:
 #if defined(AT32F43x)
-    {
-        //re-enable exint
-        EXINT->inten=ExIntReg;
-        NVIC_EnableIRQ(EXINT9_5_IRQn);
-        NVIC_EnableIRQ(EXINT15_10_IRQn);
-        NVIC_EnableIRQ(TMR20_OVF_IRQn);
-        //disable USB
-        NVIC_EnableIRQ(OTGFS1_IRQn);
-        //disable uart 1\2
-        NVIC_EnableIRQ(USART1_IRQn);
-        NVIC_EnableIRQ(USART2_IRQn);
-        NVIC_EnableIRQ(USART3_IRQn);
-    }
+    //re-enable exint
+    EXINT->inten=ExIntReg;
+    NVIC_EnableIRQ(EXINT9_5_IRQn);
+    NVIC_EnableIRQ(EXINT15_10_IRQn);
+    //re-enable USB
+    NVIC_EnableIRQ(TMR20_OVF_IRQn);//TODO:tmr20 should be removed after
+    NVIC_EnableIRQ(OTGFS1_IRQn);
+    //re-enable uart 1\2\3
+    NVIC_EnableIRQ(USART1_IRQn);
+    NVIC_EnableIRQ(USART2_IRQn);
+    NVIC_EnableIRQ(USART3_IRQn);
 #endif
     return (LastACK == brSUCCESS);
 }

--- a/src/main/io/serial_4way_avrootloader.c
+++ b/src/main/io/serial_4way_avrootloader.c
@@ -164,10 +164,21 @@ static uint8_t BL_ReadBuf(uint8_t *pstring, uint8_t len)
  *  后继处理： 测试通过后，尝试atomic_block(nvic_prio_max) 方式
  */
 #if defined(AT32F43x)
-    ATOMIC_BLOCK(NVIC_PRIO_MAX){
+    {
         //disable exint
         ExIntReg=EXINT->inten;
         EXINT->inten=0;//DISABLE ALL EXINT
+        //disable 5-15 EXINT
+        NVIC_DisableIRQ(EXINT9_5_IRQn);
+        NVIC_DisableIRQ(EXINT15_10_IRQn);
+        //disable USB TIMER
+        NVIC_DisableIRQ(TMR20_OVF_IRQn);
+        //disable USB
+        NVIC_DisableIRQ(OTGFS1_IRQn);
+        //disable uart 1\2
+        NVIC_DisableIRQ(USART1_IRQn);
+        NVIC_DisableIRQ(USART2_IRQn);
+        NVIC_DisableIRQ(USART3_IRQn);
     }
 #endif
     do {
@@ -190,10 +201,19 @@ static uint8_t BL_ReadBuf(uint8_t *pstring, uint8_t len)
     }
 timeout:
 #if defined(AT32F43x)
-    ATOMIC_BLOCK(NVIC_PRIO_MAX){
+    {
         //re-enable exint
         EXINT->inten=ExIntReg;
-	}
+        NVIC_EnableIRQ(EXINT9_5_IRQn);
+        NVIC_EnableIRQ(EXINT15_10_IRQn);
+        NVIC_EnableIRQ(TMR20_OVF_IRQn);
+        //disable USB
+        NVIC_EnableIRQ(OTGFS1_IRQn);
+        //disable uart 1\2
+        NVIC_EnableIRQ(USART1_IRQn);
+        NVIC_EnableIRQ(USART2_IRQn);
+        NVIC_EnableIRQ(USART3_IRQn);
+    }
 #endif
     return (LastACK == brSUCCESS);
 }


### PR DESCRIPTION
因为在刷写电调的过程中刷写电调的bug，根据at32的特性，关闭部分中断，保证 esc-4-way 模拟串口不受影响 
#50 