### PR TITLE
FIX: SPI_DPS310 not gated correctly

### DIFF
--- a/src/main/drivers/barometer/barometer_dps310.c
+++ b/src/main/drivers/barometer/barometer_dps310.c
@@ -47,7 +47,7 @@
 // 10 MHz max SPI frequency
 #define DPS310_MAX_SPI_CLK_HZ 10000000
 
-#if defined(USE_BARO) && defined(USE_BARO_DPS310)
+#if defined(USE_BARO) && (defined(USE_BARO_DPS310) || defined(USE_BARO_SPI_DPS310))
 
 #define DPS310_I2C_ADDR             0x76
 


### PR DESCRIPTION
It should allow access to the DPS310 via the SPI bus.

![DPS310 test](https://user-images.githubusercontent.com/41096247/234550057-7cd885c5-db7b-4e10-9138-43c47a5eb3dd.png)
