### PR TITLE
[Target Update]: Remove ICM42688p drivers from at32 targets

### DIFF
--- a/src/main/target/BETAFPVF435/target.h
+++ b/src/main/target/BETAFPVF435/target.h
@@ -51,14 +51,12 @@
 
 #define USE_GYRO
 #define USE_GYRO_SPI_MPU6000
-#define USE_GYRO_SPI_ICM42688P
 #define GYRO_1_ALIGN            CW270_DEG
 
 #define USE_ACC
 #define USE_ACCGYRO_BMI270
 #define USE_ACC_SPI_MPU6000
 #define USE_ACCGYRO_LSM6DSO
-#define USE_ACC_SPI_ICM42688P
 
 // *************** Baro **************************
 #define USE_BARO

--- a/src/main/target/BETAFPVF435/target.mk
+++ b/src/main/target/BETAFPVF435/target.mk
@@ -5,7 +5,6 @@ FEATURES       +=  VCP ONBOARDFLASH
 
 TARGET_SRC = \
             drivers/accgyro/accgyro_spi_mpu6000.c \
-            drivers/accgyro/accgyro_spi_icm426xx.c\
             drivers/barometer/barometer_bmp280.c \
             drivers/barometer/barometer_dps310.c\
             $(ROOT)/lib/main/BoschSensortec/BMI270-Sensor-API/bmi270.c \

--- a/src/main/target/EMSRPROTO4/target.h
+++ b/src/main/target/EMSRPROTO4/target.h
@@ -88,7 +88,6 @@
 #define USE_GYRO
 // #define USE_GYRO_SPI_MPU6500  //debug only
 // #define USE_ACC_SPI_MPU6500		//debug only
-#define USE_GYRO_SPI_ICM42688P
 #define USE_ACCGYRO_BMI270
 #define USE_ACCGYRO_ASM330LHH
 #define USE_ACCGYRO_LSM6DSL
@@ -97,7 +96,6 @@
 #define USE_ACCGYRO_SH3001
 
 #define USE_ACC
-#define USE_ACC_SPI_ICM42688P
 
 
 // *************** OSD *****************************

--- a/src/main/target/EMSRPROTO4/target.mk
+++ b/src/main/target/EMSRPROTO4/target.mk
@@ -6,7 +6,6 @@ FEATURES       +=  VCP ONBOARDFLASH
 
 TARGET_SRC = \
         drivers/accgyro/accgyro_spi_mpu6000.c \
-        drivers/accgyro/accgyro_spi_icm426xx.c\
         drivers/barometer/barometer_bmp280.c \
         drivers/barometer/barometer_dps310.c\
         drivers/compass/compass_hmc5883l.c\

--- a/src/main/target/NEUTRONRCF435MINI/target.h
+++ b/src/main/target/NEUTRONRCF435MINI/target.h
@@ -88,7 +88,6 @@
 #define USE_GYRO
 // #define USE_GYRO_SPI_MPU6500  //debug only
 // #define USE_ACC_SPI_MPU6500		//debug only
-#define USE_GYRO_SPI_ICM42688P
 #define USE_ACCGYRO_BMI270
 #define USE_ACCGYRO_ASM330LHH
 #define USE_ACCGYRO_LSM6DSL
@@ -97,7 +96,6 @@
 #define USE_ACCGYRO_SH3001
 
 #define USE_ACC
-#define USE_ACC_SPI_ICM42688P
 
 
 // *************** OSD *****************************

--- a/src/main/target/NEUTRONRCF435MINI/target.mk
+++ b/src/main/target/NEUTRONRCF435MINI/target.mk
@@ -6,7 +6,6 @@ FEATURES       +=  VCP ONBOARDFLASH
 
 TARGET_SRC = \
         drivers/accgyro/accgyro_spi_mpu6000.c \
-        drivers/accgyro/accgyro_spi_icm426xx.c\
         drivers/barometer/barometer_bmp280.c \
         drivers/barometer/barometer_dps310.c\
         drivers/compass/compass_hmc5883l.c\

--- a/src/main/target/NEUTRONRCF435SE/target.h
+++ b/src/main/target/NEUTRONRCF435SE/target.h
@@ -91,7 +91,6 @@
 #define USE_GYRO
 // #define USE_GYRO_SPI_MPU6500  //debug only
 // #define USE_ACC_SPI_MPU6500		//debug only
-#define USE_GYRO_SPI_ICM42688P
 #define USE_ACCGYRO_BMI270
 #define USE_ACCGYRO_ASM330LHH
 #define USE_ACCGYRO_LSM6DSL
@@ -100,7 +99,6 @@
 #define USE_ACCGYRO_SH3001
 
 #define USE_ACC
-#define USE_ACC_SPI_ICM42688P
 
 
 // *************** OSD *****************************

--- a/src/main/target/NEUTRONRCF435SE/target.mk
+++ b/src/main/target/NEUTRONRCF435SE/target.mk
@@ -6,7 +6,6 @@ FEATURES       +=  VCP ONBOARDFLASH
 
 TARGET_SRC = \
             drivers/accgyro/accgyro_spi_mpu6000.c \
-            drivers/accgyro/accgyro_spi_icm426xx.c\
             drivers/barometer/barometer_bmp280.c \
             drivers/barometer/barometer_dps310.c\
             drivers/compass/compass_hmc5883l.c\


### PR DESCRIPTION
Remove icm42688 driver from multiple targets to help reduce maintenance burden and meaningless argument.